### PR TITLE
Make delay variable for hello echo multiaction

### DIFF
--- a/rulebooks/hello_echo_multiaction_multirule_shutdown.yml
+++ b/rulebooks/hello_echo_multiaction_multirule_shutdown.yml
@@ -4,13 +4,13 @@
   sources:
     - ansible.eda.range:
         limit: 10
-        delay: 2
+        delay: "{{ delay_seconds | default(2) | int }}"
   rules:
     - name: Set event
       condition: event.i == 1
       actions:
         - debug:
-            msg: "One has come"
+            msg: "One has come, delay seconds is {{ delay_seconds | default(2) | int }}"
         - print_event:
             pretty: true
         - post_event:


### PR DESCRIPTION
We need to take control over the delay of this rulebook for restart policy sanity tests, to ensure that the rulebook is running long enough to protect against false positives in case of test suite underperformance.