### PR TITLE
chore: rulebooks for testing run_workflow_template_action

### DIFF
--- a/rulebooks/basic_workflow_template.yml
+++ b/rulebooks/basic_workflow_template.yml
@@ -1,0 +1,19 @@
+---
+- name: Test run workflow templates
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+        delay: 10
+  rules:
+    - name: "Run workflow template"
+      condition: event.i == 0
+      action:
+        run_workflow_template:
+          name: workflow_basic
+          job_args:
+            extra_vars:
+              fake_execution_time: "2"
+          retries: 1
+          delay: 10
+          organization: Default

--- a/rulebooks/basic_workflow_template_failed.yml
+++ b/rulebooks/basic_workflow_template_failed.yml
@@ -1,0 +1,19 @@
+---
+- name: Test run workflow templates with failure
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 5
+        delay: 10
+  rules:
+    - name: "Run workflow template"
+      condition: event.i == 0
+      action:
+        run_workflow_template:
+          name: workflow_basic_fail
+          job_args:
+            extra_vars:
+              fake_execution_time: "2"
+          retries: 1
+          delay: 10
+          organization: Default


### PR DESCRIPTION
These rulebooks will be used in e2e tests to test the new feature in ansible-rulebook. The rulebooks test workflow templates

  * success
  * success and failure
  https://issues.redhat.com/browse/AAP-15391