### PR TITLE
test: colon with spaces in condition

### DIFF
--- a/rulebooks/colons_with_spaces_in_condition.yml
+++ b/rulebooks/colons_with_spaces_in_condition.yml
@@ -1,0 +1,30 @@
+---
+- name: colon with spaces in condition
+  hosts: all
+  sources:
+    - name: simple source
+      ansible.eda.generic:
+        payload:
+          - a: 'abc : def'
+          - b: 'xyz : 123'
+          - c: 'xyz : 345'
+          - url: http://www.example.com
+  rules:
+    - name: r1
+      condition: 'event.a == "abc : def"'
+      action:
+        print_event:
+    - name: r2
+      condition: >
+        event.b == "xyz : 123"
+      action:
+        print_event:
+    - name: r3
+      condition: |
+        event.c == "xyz : 345"
+      action:
+        print_event:
+    - name: r4
+      condition: event.url == "http://www.example.com"
+      action:
+        print_event:


### PR DESCRIPTION
If there is a colon with spaces in a condition then the whole condition needs to be quoted. Since colon is a reserved keyword in yaml https://issues.redhat.com/browse/AAP-14226