### PR TITLE
Number of loops in awx_long_running

### DIFF
--- a/rulebooks/awx_long_running.yml
+++ b/rulebooks/awx_long_running.yml
@@ -3,7 +3,7 @@
   hosts: all
   sources:
     - ansible.eda.generic:
-        loop_count: 63072000 # two years
+        loop_count: "{{ total_loops | default(63072000) | int }}" # default two years
         loop_delay: 1
         event_delay: 5
         create_index: iteration


### PR DESCRIPTION
Allow for specifying the total number of loops in the awx_long_running rulebook.