### PR TITLE
add a two minute time-limited duration of events

### DIFF
--- a/extensions/eda/rulebooks/two_minutes_of_events.yml
+++ b/extensions/eda/rulebooks/two_minutes_of_events.yml
@@ -1,0 +1,18 @@
+---
+- name: "Two minutes of events"
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 120
+        delay: 1  # 120 seconds
+  rules:
+    - name: Two minutes of events rule
+      condition: >-
+        event.i in [
+          0, 10, 20, 30, 40, 50,
+          60, 70, 80, 90, 100, 110,
+          120
+        ]
+      action:
+        debug:
+          msg: "Event {{ event.i }} triggered"


### PR DESCRIPTION
Supports white-box testing of redis availability dependencies.