### PR TITLE
add specified duration rulebooks

### DIFF
--- a/extensions/eda/rulebooks/one_minute_of_events.yml
+++ b/extensions/eda/rulebooks/one_minute_of_events.yml
@@ -1,0 +1,16 @@
+---
+- name: "One minute of events"
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 60
+        delay: 1  # 60 seconds
+  rules:
+    - name: One minute of events rule
+      condition: >-
+        event.i in [
+          0, 10, 20, 30, 40, 50, 59
+        ]
+      action:
+        debug:
+          msg: "Event {{ event.i }} triggered"

--- a/extensions/eda/rulebooks/two_minutes_of_events.yml
+++ b/extensions/eda/rulebooks/two_minutes_of_events.yml
@@ -1,0 +1,18 @@
+---
+- name: "Two minutes of events"
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 120
+        delay: 1  # 120 seconds
+  rules:
+    - name: Two minutes of events rule
+      condition: >-
+        event.i in [
+          0, 10, 20, 30, 40, 50,
+          60, 70, 80, 90, 100, 110,
+          120
+        ]
+      action:
+        debug:
+          msg: "Event {{ event.i }} triggered"


### PR DESCRIPTION
Adds one and two minute duration rulebooks to stable-1.1 branch for 2.5 white-box testing.