### PR TITLE
feat: servicenow webhooks integration rulebook

### DIFF
--- a/extensions/eda/rulebooks/webhook_servicenow.yml
+++ b/extensions/eda/rulebooks/webhook_servicenow.yml
@@ -1,0 +1,29 @@
+---
+- name: Run a webhook listener service for ServiceNow integration tests
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+  rules:
+    - name: ServiceNow Incident
+      condition: event.payload.number contains "INC"
+      action:
+        debug:
+          msg: "ServiceNow Incident received!"
+
+    - name: ServiceNow Problem
+      condition: event.payload.number contains "PRB"
+      action:
+        debug:
+          msg: "ServiceNow Problem received!"
+
+    - name: ServiceNow Catalog Request
+      condition: event.payload.number contains "REQ"
+      action:
+        debug:
+          msg: "ServiceNow Catalog Request received!"
+
+    - name: Shutdown
+      condition: event.payload.shutdown is defined
+      action:
+        shutdown:
+


### PR DESCRIPTION
- adds a simple rulebook to catch ServiceNow webhook calls for its Incidents, Problems, and Catalog Requests events