### PR TITLE
AAP-13456 include_events for workflow templates

### DIFF
--- a/extensions/eda/rulebooks/workflow_template_with_include_events.yml
+++ b/extensions/eda/rulebooks/workflow_template_with_include_events.yml
@@ -1,0 +1,28 @@
+---
+- name: Test run workflow templates with include_events
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 3
+        delay: 5
+  rules:
+    - name: "Run workflow template with default settings"
+      condition: event.i == 2
+      action:
+        run_workflow_template:
+          name: "{{ workflow_template_name }}"
+          organization: "{{ organization | default('Default') }}"
+    - name: "Run workflow template with include events set to True"
+      condition: event.i == 1
+      action:
+        run_workflow_template:
+          name: "{{ workflow_template_name }}"
+          include_events: True
+          organization: "{{ organization | default('Default') }}"
+    - name: "Run workflow template with include events set to False"
+      condition: event.i == 0
+      action:
+        run_workflow_template:
+          name: "{{ workflow_template_name }}"
+          include_events: False
+          organization: "{{ organization | default('Default') }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-13456

include_events is True by default.

This PR adds a rulebook that runs the same workflow in a action with include_events set to False and True.
The one with include_events set to True fails
The one with no include_events specified defaults to True and fails.
The one with include_events set to False works.