### PR TITLE
chore: remove run_job_template action

### DIFF
--- a/extensions/eda/rulebooks/fails/wrong_source.yml
+++ b/extensions/eda/rulebooks/fails/wrong_source.yml
@@ -5,15 +5,6 @@
     - ansible.eda.idonotexist:
         limit: 6
   rules:
-    - name: Run job template
-      condition: event.i == 1
-      action:
-        run_job_template:
-          name: Hello World
-          organization: Default
-          job_args:
-            extra_vars:
-              hello: Fred
     - name: Debug
       condition: event.i == 2
       action:


### PR DESCRIPTION
This action is not necessary for this rulebook since we are only testing for a wrong source and this action forces us to use a RHAAP token in the test unnecessarily.