### PR TITLE
Add lock mechanism test rulebook for AAP-51496

### DIFF
--- a/extensions/eda/rulebooks/data_center_label.yml
+++ b/extensions/eda/rulebooks/data_center_label.yml
@@ -1,0 +1,23 @@
+---
+- name: Test run job templates with labels
+  hosts: all
+  sources:
+    - ansible.eda.generic:
+        payload:
+           - name: "{{ event_name }}"
+             error: 678
+        shutdown_after: 45
+  rules:
+    - name: "Run job template"
+      condition: event.error >= 303
+      action:
+        run_job_template:
+          name: "{{ job_template_name }}"
+          organization: "{{ organization }}"
+          job_args:
+            extra_vars:
+              hello: Fred
+          labels: 
+            - "{{ event.name }}"
+            - I am label
+            - "{{ user_label }}"

--- a/extensions/eda/rulebooks/data_center_lock.yml
+++ b/extensions/eda/rulebooks/data_center_lock.yml
@@ -1,0 +1,31 @@
+---
+- name: Test run job templates with lock
+  hosts: all
+  execution_strategy: parallel
+  sources:
+    - ansible.eda.generic:
+        payload:
+           - name: DataCenter1
+             error: 678
+             sleep: 20
+           - name: DataCenter2
+             error: 303
+             sleep: 15
+           - name: DataCenter3
+             error: 353
+             sleep: 10
+        loop_count: 3   
+        shutdown_after: 90
+        create_index: index
+  rules:
+    - name: "Run job template"
+      condition: event.error >= 303
+      action:
+        run_job_template:
+          name: "{{ job_template_name }}" 
+          organization: "{{ organization | default('Default') }}"
+          job_args:
+            extra_vars:
+              hello: Fred
+              sleep_interval: "{{ event.sleep }}"
+          lock: "{{ event.name }}"


### PR DESCRIPTION
## Summary
- Add `lock_parallel_execution.yml` for testing EDA lock mechanism
- Tests parallel execution with sequential locking behavior
- Demonstrates datacenter vs network lock groups
