### PR TITLE
feat: add runtime override for job template names

### DIFF
--- a/extensions/eda/rulebooks/awx_basic_custom_limit.yml
+++ b/extensions/eda/rulebooks/awx_basic_custom_limit.yml
@@ -31,6 +31,6 @@
       actions:
         - run_job_template:
             organization: Default
-            name: run_basic
+            name: "{{ override_run_basic | default('run_basic') }}"
             job_args:
               limit: "{{ event.hosts }}"

--- a/extensions/eda/rulebooks/awx_long_running.yml
+++ b/extensions/eda/rulebooks/awx_long_running.yml
@@ -32,7 +32,7 @@
       actions:
         - run_job_template:
             organization: Default
-            name: run_basic
+            name: "{{ override_run_basic | default('run_basic') }}"
 
         - debug:
             msg: "Awx long running rulebook, event {{ event.iteration }}"

--- a/extensions/eda/rulebooks/awx_storm.yml
+++ b/extensions/eda/rulebooks/awx_storm.yml
@@ -18,7 +18,7 @@
             msg: "JT launched for #{{ event.index }}"
 
         - run_job_template:
-            name: run_basic
+            name: "{{ override_run_basic | default('run_basic') }}"
             organization: Default
             job_args:
               extra_vars:

--- a/extensions/eda/rulebooks/awx_storm_single_action.yml
+++ b/extensions/eda/rulebooks/awx_storm_single_action.yml
@@ -15,7 +15,7 @@
       condition: event.state == "down"
       action:
         run_job_template:
-          name: run_basic
+          name: "{{ override_run_basic | default('run_basic') }}"
           organization: Default
           job_args:
             extra_vars:

--- a/extensions/eda/rulebooks/basic_short.yml
+++ b/extensions/eda/rulebooks/basic_short.yml
@@ -13,7 +13,7 @@
       actions:
         - run_job_template:
             organization: Default
-            name: run_basic
+            name: "{{ override_run_basic | default('run_basic') }}"
             job_args:
               extra_vars:
                 fake_execution_time: "5"

--- a/extensions/eda/rulebooks/basic_workflow_template.yml
+++ b/extensions/eda/rulebooks/basic_workflow_template.yml
@@ -10,7 +10,7 @@
       condition: event.i == 0
       action:
         run_workflow_template:
-          name: workflow_basic
+          name: "{{ override_workflow_basic | default('workflow_basic') }}"
           job_args:
             extra_vars:
               fake_execution_time: "2"

--- a/extensions/eda/rulebooks/basic_workflow_template_failed.yml
+++ b/extensions/eda/rulebooks/basic_workflow_template_failed.yml
@@ -10,7 +10,7 @@
       condition: event.i == 0
       action:
         run_workflow_template:
-          name: workflow_basic_fail
+          name: "{{ override_workflow_basic_fail | default('workflow_basic_fail') }}"
           job_args:
             extra_vars:
               fake_execution_time: "2"

--- a/extensions/eda/rulebooks/fails/awx_fail.yml
+++ b/extensions/eda/rulebooks/fails/awx_fail.yml
@@ -11,5 +11,5 @@
       action:
         run_job_template:
           organization: Default
-          name: fail_basic
+          name: "{{ override_fail_basic | default('fail_basic') }}"
 

--- a/extensions/eda/rulebooks/multi_action_delayed.yml
+++ b/extensions/eda/rulebooks/multi_action_delayed.yml
@@ -13,7 +13,7 @@
             msg: "Good morning"
         - run_job_template:
             organization: Default
-            name: run_basic
+            name: "{{ override_run_basic | default('run_basic') }}"
             job_args:
               extra_vars:
                 fake_execution_time: "3"
@@ -21,7 +21,7 @@
             msg: "Good night"
         - run_job_template:
             organization: Default
-            name: run_basic
+            name: "{{ override_run_basic | default('run_basic') }}"
             job_args:
               extra_vars:
                 fake_execution_time: "2"

--- a/extensions/eda/rulebooks/succeed_and_fail.yml
+++ b/extensions/eda/rulebooks/succeed_and_fail.yml
@@ -11,16 +11,16 @@
         actions:
           - run_job_template:
               organization: Default
-              name: run_basic
+              name: "{{ override_run_basic | default('run_basic') }}"
               job_args:
                 extra_vars:
                   fake_execution_time: '1'
           - run_job_template:
               organization: Default
-              name: fail_basic
+              name: "{{ override_fail_basic | default('fail_basic') }}"
           - run_job_template:
               organization: Default
-              name: run_basic
+              name: "{{ override_run_basic | default('run_basic') }}"
               job_args:
                 extra_vars:
                   fake_execution_time: '1'


### PR DESCRIPTION
## Summary

This PR enables parallel test execution by allowing job template names to be overridden at runtime via extra variables.

### Changes

- Replaced hardcoded job template names with Jinja2 template variables that default to original values
  - `run_basic` → `{{ override_run_basic | default('run_basic') }}`
  - `fail_basic` → `{{ override_fail_basic | default('fail_basic') }}`

### Affected Rulebooks

- `awx_basic_custom_limit.yml`
- `awx_long_running.yml`
- `awx_storm.yml`
- `awx_storm_single_action.yml`
- `basic_short.yml`
- `fails/awx_fail.yml`
- `multi_action_delayed.yml`
- `succeed_and_fail.yml`

### Benefits

- Allows multiple test runs to execute in parallel using distinct job templates
- Each test run can use the same underlying playbook with different job template instances
- Avoids conflicts and improves test execution efficiency
- Maintains backward compatibility - defaults to original template names when override variables are not provided

### Usage Example

When running tests in parallel, you can now pass `override_run_basic` and/or `override_fail_basic` as extra variables to use different job template names:

```yaml
extra_vars:
  override_run_basic: "run_basic_test_1"
  override_fail_basic: "fail_basic_test_1"
```

## Test plan

- [ ] Verify rulebooks work with default job template names (backward compatibility)
- [ ] Verify rulebooks work when override variables are provided
- [ ] Test parallel execution with multiple instances using different job template names
- [ ] Confirm all affected rulebooks execute successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)