### PR TITLE
Adds debug playbook for performance testing.

### DIFF
--- a/extensions/eda/rulebooks/performance/kafka_debug.yaml
+++ b/extensions/eda/rulebooks/performance/kafka_debug.yaml
@@ -1,0 +1,30 @@
+---
+# Kafka throughput benchmark — consumes events from a Kafka topic and
+# runs the Demo Job Template to measure realistic event-processing rate.
+- name: Kafka throughput benchmark
+  hosts: all
+  sources:
+    - name: kafka_benchmark
+      ansible.eda.kafka:
+        host: "{{ host | default('localhost') }}"
+        port: "{{ port | default('9092') }}"
+        cafile: "{{ eda.filename.cafile | default(None) }}"
+        certfile: "{{ eda.filename.certfile | default(None) }}"
+        keyfile: "{{ eda.filename.keyfile | default(None) }}"
+        encoding: "{{ encoding | default('utf-8') }}"
+        topic: "{{ topic | default('benchmark') }}"
+        group_id: "{{ group_id | default('benchmark') }}"
+        offset: "{{ offset | default('earliest') }}"
+        security_protocol: "{{ security_protocol | default('PLAINTEXT') }}"
+        sasl_mechanism: "{{ sasl_mechanism | default('PLAIN') }}"
+        sasl_plain_username: "{{ sasl_plain_username | default(None) }}"
+        sasl_plain_password: "{{ sasl_plain_password | default(None) }}"
+        check_hostname: "{{ check_hostname | default(None) }}"
+        verify_mode: "{{ verify_mode | default('CERT_NONE') }}"
+        feedback: false
+  rules:
+    - name: consume all events
+      condition: event.body is defined
+      action:
+        debug:
+          msg: "Consumed event with body: {{ event.body }}"


### PR DESCRIPTION
this is needed because the kafka_benchmark.yml rulebook triggers a playbook with each event, which is very slow and atf test-suite test times out before processing more than 1-2 events.