### PR TITLE
Add webhook_port_echo_payload rulebook

### DIFF
--- a/extensions/eda/rulebooks/webhook_port.yml
+++ b/extensions/eda/rulebooks/webhook_port.yml
@@ -5,6 +5,12 @@
     - ansible.eda.webhook:
         port: 5000
   rules:
+    - name: Webhook event echo payload
+      condition: event.payload.ping == "pong" and event.payload.echo_mode == "payload"
+      action:
+        debug:
+          msg: "{{ event.payload }}"
+
     - name: Webhook event
       condition: event.payload.ping == "pong"
       action:


### PR DESCRIPTION
## Summary
- Add a new rule that echoes the full event payload when echo_mode == "payload" is present. Existing behavior is
preserved — events without echo_mode still trigger the original `"Webhook triggered!"` message.
- Used by eda-test-suite to verify activation log sanitization for [AAP-76187](https://issues.redhat.com/browse/AAP-76187) (CVE-2025-2877)

## Test plan
- [ ] Verify rulebook is importable by an EDA project
- [ ] Verify activation using this rulebook logs event payload content

🤖 Generated with [Claude Code](https://claude.com/claude-code)